### PR TITLE
Fix deprecation warning for `vim.tbl_islist`

### DIFF
--- a/lua/borderline/util.lua
+++ b/lua/borderline/util.lua
@@ -2,6 +2,9 @@
 local bl_borders = require('borderline.borders')
 local bl_config = require('borderline.config')
 
+---@diagnostic disable-next-line: deprecated
+local islist = vim.islist or vim.tbl_islist
+
 local M = {}
 
 ---@type BorderlineOptions
@@ -44,7 +47,7 @@ M.normalize_border = function(border)
     end
     border = border_tbl
   end
-  if type(border) == 'table' and vim.tbl_islist(border) and not next(border) then
+  if type(border) == 'table' and islist(border) and not next(border) then
     border = M.border_styles().none
   end
   return border


### PR DESCRIPTION
Use [`vim.islist()`](https://neovim.io/doc/user/lua.html#vim.islist()) where available

[`vim.tbl_islist()`](https://neovim.io/doc/user/deprecated.html#vim.tbl_islist()) is deprecated in Nvim 0.10 and gives this warning at startup:
```
vim.tbl_islist is deprecated. Run ":checkhealth vim.deprecated" for more information
```